### PR TITLE
fix missing manifest version error

### DIFF
--- a/config/custom_components/airco2ntrol/manifest.json
+++ b/config/custom_components/airco2ntrol/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://github.com/jansauer/home-assistant_config/tree/master/config/custom_components/airco2ntrol",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@jansauer"]
+  "codeowners": ["@jansauer"],
+  "version": "0.0.1"
 }


### PR DESCRIPTION
This fixes: ERROR (SyncWorker_0) [homeassistant.loader] The custom integration 'airco2ntrol' does not have a version key in the manifest file and was blocked from loading. See https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes#versions for more details